### PR TITLE
feat(autocmd): Use filetype liquid for markdown/html files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+mise.toml

--- a/lua/jekyll/init.lua
+++ b/lua/jekyll/init.lua
@@ -186,7 +186,6 @@ local is_jekyll_window = function()
   return gem_match
 end
 
----Autocommands for making/deleting user_commands on DirChanged event
 ---@param opts JekyllNvimOptions
 ---@return integer? augroup id number
 local setup_autocmds = function(opts)
@@ -199,6 +198,14 @@ local setup_autocmds = function(opts)
   if not augroup_exists() then
     vim.api.nvim_create_augroup(opts.augroup_name, {})
   end
+  autocmd_create_del_user_commands(opts)
+  autocmd_markup_files_use_liquid_ft(opts)
+  return vim.api.nvim_create_augroup(opts.augroup_name, { clear = false })
+end
+
+---Autocommands for making/deleting user_commands on DirChanged event
+---@param opts JekyllNvimOptions
+local autocmd_create_del_user_commands = function(opts)
   vim.api.nvim_create_autocmd('DirChanged', {
     desc = 'Decide whether cwd needs Jekyll user_commands',
     group = opts.augroup_name,
@@ -210,7 +217,22 @@ local setup_autocmds = function(opts)
       end
     end,
   })
-  return vim.api.nvim_create_augroup(opts.augroup_name, { clear = false })
+end
+
+---Autocommands for explicitly using the `liquid` filetype so as to get the benefits of snippets, etc...
+---@param opts JekyllNvimOptions
+local autocmd_markup_files_use_liquid_ft = function(opts)
+  vim.api.nvim_create_autocmd('BufReadPost', {
+    desc = 'Change filetype of html/markdown to liquid',
+    group = opts.augroup_name,
+    callback = function(_)
+      if is_jekyll_window() then
+        if vim.bo.filetype == 'markdown' or vim.bo.filetype == 'html' then
+          vim.bo.filetype = 'liquid'
+        end
+      end
+    end,
+  })
 end
 
 ---@param opts? JekyllNvimOptions

--- a/lua/jekyll/init.lua
+++ b/lua/jekyll/init.lua
@@ -189,6 +189,7 @@ end
 ---@param opts JekyllNvimOptions
 ---@return integer? augroup id number
 local setup_autocmds = function(opts)
+  -- Create augroup, or retrieve existing one
   local augroup = vim.api.nvim_create_augroup(opts.augroup_name, { clear = false })
 
   ---Autocommand for making/deleting user_commands on DirChanged event

--- a/lua/jekyll/init.lua
+++ b/lua/jekyll/init.lua
@@ -189,10 +189,11 @@ end
 ---@param opts JekyllNvimOptions
 ---@return integer? augroup id number
 local setup_autocmds = function(opts)
-  -- Create augroup, or retrieve existing one
+  ---Create augroup, or retrieve existing one
   local augroup = vim.api.nvim_create_augroup(opts.augroup_name, { clear = false })
 
   ---Autocommand for making/deleting user_commands on DirChanged event
+  ---@param _opts JekyllNvimOptions
   local autocmd_create_del_user_commands = function(_opts)
     vim.api.nvim_create_autocmd('DirChanged', {
       desc = 'Decide whether cwd needs Jekyll user_commands',

--- a/lua/jekyll/init.lua
+++ b/lua/jekyll/init.lua
@@ -37,7 +37,7 @@ local create_buffer_with_name_and_content = function(path, content)
   else
     buf = vim.api.nvim_create_buf(false, false)
     vim.api.nvim_buf_set_name(buf, path)
-    vim.api.nvim_set_option_value('filetype', 'markdown', { buf = buf })
+    vim.api.nvim_set_option_value('filetype', 'liquid', { buf = buf })
     vim.schedule(function()
       vim.api.nvim_set_option_value('modifiable', true, { buf = buf })
       vim.api.nvim_set_current_buf(buf)
@@ -186,6 +186,11 @@ local is_jekyll_window = function()
   return gem_match
 end
 
+---Determines if the current buffer is on the cdpath of a jekyll window
+local is_jekyll_buffer = function()
+  return is_jekyll_window() and vim.fn.findfile(vim.fn.expand('%'), vim.o.cdpath)
+end
+
 ---@param opts JekyllNvimOptions
 ---@return integer? augroup id number
 local setup_autocmds = function(opts)
@@ -211,11 +216,11 @@ local setup_autocmds = function(opts)
   ---Autocommand for explicitly using the `liquid` filetype so as to get the benefits of snippets, etc...
   ---@param _opts JekyllNvimOptions
   local autocmd_markup_files_use_liquid_ft = function(_opts)
-    vim.api.nvim_create_autocmd('BufReadPost', {
+    vim.api.nvim_create_autocmd('BufEnter', {
       desc = 'Change filetype of html/markdown to liquid',
       group = _opts.augroup_name,
       callback = function(_)
-        if is_jekyll_window() then
+        if is_jekyll_buffer() then
           if vim.bo.filetype == 'markdown' or vim.bo.filetype == 'html' then
             vim.bo.filetype = 'liquid'
           end

--- a/lua/jekyll/init.lua
+++ b/lua/jekyll/init.lua
@@ -23,7 +23,7 @@ local random_string = function(k)
   return string.char(table.unpack(pw, 1, k))
 end
 
-local modeline = { '', '<!--', 'vim:set filetype=liquid', '-->' }
+local modeline = { '', '<!-- vim: set ft=liquid -->' }
 
 ---Main point of entry into creating documents that Jekyll understands
 ---@param path string

--- a/lua/jekyll/init.lua
+++ b/lua/jekyll/init.lua
@@ -23,6 +23,8 @@ local random_string = function(k)
   return string.char(table.unpack(pw, 1, k))
 end
 
+local modeline = { '', '<!--', 'vim:set filetype=liquid', '-->' }
+
 ---Main point of entry into creating documents that Jekyll understands
 ---@param path string
 ---@param content string[]
@@ -42,7 +44,8 @@ local create_buffer_with_name_and_content = function(path, content)
       vim.api.nvim_set_option_value('modifiable', true, { buf = buf })
       vim.api.nvim_set_current_buf(buf)
       vim.api.nvim_buf_set_lines(buf, 0, -1, true, content)
-      local last_line = vim.api.nvim_buf_line_count(buf)
+      vim.api.nvim_buf_set_lines(buf, -1, -1, true, modeline)
+      local last_line = vim.api.nvim_buf_line_count(buf) - #modeline
       vim.api.nvim_win_set_cursor(0, { last_line, 0 })
     end)
   end
@@ -236,6 +239,7 @@ end
 
 ---@param opts? JekyllNvimOptions
 M.setup = function(opts)
+  ---@type JekyllNvimOptions
   local merged_options = vim.tbl_extend('force', M.opts, opts or {})
   if is_jekyll_window() then
     create_user_commands()


### PR DESCRIPTION
When in a Jekyll project, opening a markdown/html file should be interpreted as opening a Liquid template. This will avail snippets and lsp support to users.